### PR TITLE
비즈니스 로직 구현

### DIFF
--- a/src/main/kotlin/ecommerce/server/coupon/application/CouponFacade.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/application/CouponFacade.kt
@@ -1,0 +1,28 @@
+package ecommerce.server.coupon.application
+
+import ecommerce.server.coupon.application.dto.IssueCoupon
+import ecommerce.server.coupon.application.dto.UserCoupons
+import ecommerce.server.coupon.domain.service.CouponIssueService
+import ecommerce.server.coupon.domain.service.CouponService
+import org.springframework.stereotype.Component
+import org.springframework.transaction.annotation.Transactional
+
+@Component
+class CouponFacade(
+    private val couponService: CouponService,
+    private val couponIssueService: CouponIssueService
+) {
+
+    @Transactional(readOnly = true)
+    fun getUserValidCoupons(userId: Long): List<UserCoupons>{
+        val couponIssues = couponIssueService.getValidCouponsByUserId(userId)
+        return UserCoupons.listFrom(couponIssues)
+    }
+
+    @Transactional
+    fun issueFirstComeCoupon(couponId: Long, userId: Long): IssueCoupon {
+        val coupon = couponService.validateCoupon(couponId)
+        val couponIssue = couponIssueService.issueCoupon(coupon, userId)
+        return IssueCoupon.from(couponIssue)
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/application/dto/CouponResult.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/application/dto/CouponResult.kt
@@ -1,0 +1,59 @@
+package ecommerce.server.coupon.application.dto
+
+import ecommerce.server.coupon.domain.DiscountType
+import ecommerce.server.coupon.domain.model.CouponIssue
+import java.time.LocalDateTime
+
+data class UserCoupons(
+    val couponId: Long,
+    val couponIssueId: Long,
+    val couponName: String,
+    val discountType: DiscountType,
+    val discountValue: Long,
+    val issuedAt: LocalDateTime,
+    val expiryDate: LocalDateTime
+){
+    companion object {
+        fun from(couponIssue: CouponIssue):UserCoupons{
+            return UserCoupons(
+                couponId = couponIssue.coupon.id!!,
+                couponIssueId = couponIssue.id!!,
+                couponName = couponIssue.coupon.name,
+                discountType = couponIssue.coupon.discountType,
+                discountValue = couponIssue.coupon.discountValue,
+                issuedAt = couponIssue.issuedAt,
+                expiryDate = couponIssue.expiryDate!!
+            )
+        }
+
+        fun listFrom(couponIssues: List<CouponIssue>): List<UserCoupons> {
+            return couponIssues.map {issue ->
+                from(issue)
+            }
+        }
+    }
+}
+
+data class IssueCoupon(
+    val couponId: Long,
+    val couponIssueId: Long,
+    val couponName: String,
+    val discountType: DiscountType,
+    val discountValue: Long,
+    val issuedAt: LocalDateTime,
+    val expiryDate: LocalDateTime
+){
+    companion object {
+        fun from(couponIssue: CouponIssue):IssueCoupon{
+            return IssueCoupon(
+                couponId = couponIssue.coupon.id!!,
+                couponIssueId = couponIssue.id!!,
+                couponName = couponIssue.coupon.name,
+                discountType = couponIssue.coupon.discountType,
+                discountValue = couponIssue.coupon.discountValue,
+                issuedAt = couponIssue.issuedAt,
+                expiryDate = couponIssue.expiryDate!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/domain/model/Coupon.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/model/Coupon.kt
@@ -33,4 +33,22 @@ class Coupon(
     @OneToMany(mappedBy = "coupon", cascade = [CascadeType.ALL], fetch = FetchType.LAZY)
     val couponIssues: MutableList<CouponIssue> = mutableListOf()
 ):BaseEntity() {
+
+    // 쿠폰 발급 가능 여부 확인
+    fun canIssue(): Boolean {
+        return issuedQuantity < totalQuantity && LocalDateTime.now().isBefore(expiryDate)
+    }
+
+    fun issue(userId: Long): CouponIssue {
+        if (!canIssue()) {
+            throw IllegalStateException("쿠폰 발급이 불가능합니다. 수량 초과 또는 만료되었습니다.")
+        }
+        val couponIssue = CouponIssue.create(this,userId)
+
+        couponIssues.add(couponIssue)
+        issuedQuantity++
+
+        return couponIssue
+    }
+
 }

--- a/src/main/kotlin/ecommerce/server/coupon/domain/model/CouponIssue.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/model/CouponIssue.kt
@@ -22,10 +22,19 @@ class CouponIssue(
     val issuedAt: LocalDateTime = LocalDateTime.now(),
 
     @Column(nullable = false)
-    val expiryDate: LocalDateTime,
+    val expiryDate: LocalDateTime? = null,
 
     @Column(name = "used_at")
     var usedAt: LocalDateTime? = null
 ):BaseEntity() {
-
+    companion object {
+        fun create(coupon: Coupon, userId: Long): CouponIssue {
+            return CouponIssue(
+                coupon = coupon,
+                userId = userId,
+                issuedAt = LocalDateTime.now(),
+                expiryDate = coupon.expiryDate
+            )
+        }
+    }
 }

--- a/src/main/kotlin/ecommerce/server/coupon/domain/repository/CouponIssueRepository.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/repository/CouponIssueRepository.kt
@@ -1,0 +1,13 @@
+package ecommerce.server.coupon.domain.repository
+
+import ecommerce.server.coupon.domain.model.CouponIssue
+import java.time.LocalDateTime
+
+interface CouponIssueRepository {
+    fun findByUserIdAndUsedAtIsNullAndExpiryDateAfter(
+        userId: Long,
+        currentDate: LocalDateTime
+    ): List<CouponIssue>
+
+    fun save(couponIssue: CouponIssue): CouponIssue
+}

--- a/src/main/kotlin/ecommerce/server/coupon/domain/repository/CouponRepository.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/repository/CouponRepository.kt
@@ -1,0 +1,8 @@
+package ecommerce.server.coupon.domain.repository
+
+import ecommerce.server.coupon.domain.model.Coupon
+
+interface CouponRepository {
+    fun findByIdWithLock(id: Long): Coupon?
+    fun findById(id: Long): Coupon?
+}

--- a/src/main/kotlin/ecommerce/server/coupon/domain/service/CouponIssueService.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/service/CouponIssueService.kt
@@ -1,0 +1,25 @@
+package ecommerce.server.coupon.domain.service
+
+import ecommerce.server.coupon.domain.model.Coupon
+import ecommerce.server.coupon.domain.model.CouponIssue
+import ecommerce.server.coupon.domain.repository.CouponIssueRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class CouponIssueService(
+    private val couponIssueRepository: CouponIssueRepository
+) {
+    @Transactional(readOnly = true)
+    fun getValidCouponsByUserId(userId: Long): List<CouponIssue> {
+        val currentDate = LocalDateTime.now()
+        return couponIssueRepository.findByUserIdAndUsedAtIsNullAndExpiryDateAfter(userId, currentDate)
+    }
+
+    @Transactional
+    fun issueCoupon(coupon: Coupon, userId: Long): CouponIssue {
+        val couponIssue = coupon.issue(userId)
+        return couponIssueRepository.save(couponIssue)
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/domain/service/CouponService.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/domain/service/CouponService.kt
@@ -1,0 +1,24 @@
+package ecommerce.server.coupon.domain.service
+
+import ecommerce.server.coupon.domain.model.Coupon
+import ecommerce.server.coupon.domain.model.CouponIssue
+import ecommerce.server.coupon.domain.repository.CouponRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+class CouponService(
+    private val couponRepository: CouponRepository
+) {
+
+    @Transactional
+    fun validateCoupon(couponId: Long): Coupon {
+        val coupon = couponRepository.findByIdWithLock(couponId)
+            ?: throw IllegalArgumentException("쿠폰을 찾을 수 없습니다: $couponId")
+
+        if (!coupon.canIssue()) {
+            throw IllegalStateException("쿠폰 발급이 불가능한 상태입니다.")
+        }
+        return coupon
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/infra/impl/CouponIssueResponseImpl.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/infra/impl/CouponIssueResponseImpl.kt
@@ -1,0 +1,23 @@
+package ecommerce.server.coupon.infra.impl
+
+import ecommerce.server.coupon.domain.model.CouponIssue
+import ecommerce.server.coupon.domain.repository.CouponIssueRepository
+import ecommerce.server.coupon.infra.jpa.JpaCouponIssueRepository
+import org.springframework.stereotype.Repository
+import java.time.LocalDateTime
+
+@Repository
+class CouponIssueResponseImpl(
+    private val jpaCouponIssueRepository: JpaCouponIssueRepository
+): CouponIssueRepository {
+    override fun findByUserIdAndUsedAtIsNullAndExpiryDateAfter(
+        userId: Long,
+        currentDate: LocalDateTime
+    ): List<CouponIssue> {
+        return jpaCouponIssueRepository.findByUserIdAndUsedAtIsNullAndExpiryDateAfter(userId, currentDate)
+    }
+
+    override fun save(couponIssue: CouponIssue): CouponIssue {
+        return jpaCouponIssueRepository.save(couponIssue)
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/infra/impl/CouponResponseImpl.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/infra/impl/CouponResponseImpl.kt
@@ -1,0 +1,20 @@
+package ecommerce.server.coupon.infra.impl
+
+import ecommerce.server.coupon.domain.model.Coupon
+import ecommerce.server.coupon.domain.repository.CouponRepository
+import ecommerce.server.coupon.infra.jpa.JpaCouponRepository
+import org.springframework.stereotype.Repository
+import kotlin.jvm.optionals.getOrNull
+
+@Repository
+class CouponResponseImpl(
+    private val jpaCouponResponse: JpaCouponRepository
+): CouponRepository {
+    override fun findByIdWithLock(id: Long): Coupon? {
+        return jpaCouponResponse.findByIdWithLock(id)
+    }
+
+    override fun findById(id: Long): Coupon? {
+        return jpaCouponResponse.findById(id).getOrNull()
+    }
+}

--- a/src/main/kotlin/ecommerce/server/coupon/infra/jpa/JpaCouponIssueRepository.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/infra/jpa/JpaCouponIssueRepository.kt
@@ -1,0 +1,12 @@
+package ecommerce.server.coupon.infra.jpa
+
+import ecommerce.server.coupon.domain.model.CouponIssue
+import org.springframework.data.jpa.repository.JpaRepository
+import java.time.LocalDateTime
+
+interface JpaCouponIssueRepository: JpaRepository<CouponIssue, Long> {
+    fun findByUserIdAndUsedAtIsNullAndExpiryDateAfter(
+        userId: Long,
+        currentDate: LocalDateTime
+    ): List<CouponIssue>
+}

--- a/src/main/kotlin/ecommerce/server/coupon/infra/jpa/JpaCouponRepository.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/infra/jpa/JpaCouponRepository.kt
@@ -1,0 +1,13 @@
+package ecommerce.server.coupon.infra.jpa
+
+import ecommerce.server.coupon.domain.model.Coupon
+import jakarta.persistence.LockModeType
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Lock
+import org.springframework.data.jpa.repository.Query
+
+interface JpaCouponRepository : JpaRepository<Coupon, Long> {
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT c FROM Coupon c WHERE c.id = :id")
+    fun findByIdWithLock(id: Long): Coupon?
+}

--- a/src/main/kotlin/ecommerce/server/coupon/presentation/CouponController.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/presentation/CouponController.kt
@@ -1,42 +1,31 @@
 package ecommerce.server.coupon.presentation
 
-import ecommerce.server.coupon.presentation.dto.CouponResponse
+import ecommerce.server.coupon.application.CouponFacade
 import ecommerce.server.coupon.presentation.dto.IssueCouponRequest
+import ecommerce.server.coupon.presentation.dto.IssueCouponResponse
+import ecommerce.server.coupon.presentation.dto.UserCouponsResponse
 import ecommerce.server.global.ApiResponse
 import org.springframework.web.bind.annotation.*
-import java.time.LocalDateTime
 
 @RestController
 @RequestMapping("/api/coupons")
-class CouponController: ICouponController {
+class CouponController(
+    private val couponFacade: CouponFacade
+): ICouponController {
 
-    //TODO: 사용자 쿠폰 조회
     @GetMapping()
     override fun getUserCoupons(
         @RequestParam userId: Long
-    ): ApiResponse<CouponResponse> {
-        val response = CouponResponse(
-            1, 1, "신규 가입 쿠폰", "FIXED",
-            "5000",
-            LocalDateTime.parse("2025-01-01T00:00:00"),
-            LocalDateTime.parse("2025-01-01T00:00:00"),
-            null
-        )
+    ): ApiResponse<List<UserCouponsResponse>> {
+        val response = UserCouponsResponse.listFrom(couponFacade.getUserValidCoupons(userId))
         return ApiResponse(200,"null", response)
     }
 
-    //TODO: 쿠폰 발급
     @PostMapping("/issue")
     override fun issueCoupon(
         @RequestBody request: IssueCouponRequest
-    ): ApiResponse<CouponResponse> {
-        val response = CouponResponse(
-            1, 1, "신규 가입 쿠폰", "FIXED",
-            "5000",
-            LocalDateTime.parse("2025-01-01T00:00:00"),
-            LocalDateTime.parse("2025-01-01T00:00:00"),
-            null
-        )
+    ): ApiResponse<IssueCouponResponse> {
+        val response = IssueCouponResponse.from(couponFacade.issueFirstComeCoupon(request.couponId, request.userId))
         return ApiResponse(200,"null", response)
     }
 }

--- a/src/main/kotlin/ecommerce/server/coupon/presentation/ICouponController.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/presentation/ICouponController.kt
@@ -1,7 +1,8 @@
 package ecommerce.server.coupon.presentation
 
-import ecommerce.server.coupon.presentation.dto.CouponResponse
 import ecommerce.server.coupon.presentation.dto.IssueCouponRequest
+import ecommerce.server.coupon.presentation.dto.IssueCouponResponse
+import ecommerce.server.coupon.presentation.dto.UserCouponsResponse
 import ecommerce.server.global.ApiResponse
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.Parameter
@@ -19,11 +20,11 @@ interface ICouponController {
     fun getUserCoupons(
         @Parameter(description = "사용자 ID", example = "1")
         @RequestParam userId: Long
-    ): ApiResponse<CouponResponse>
+    ): ApiResponse<List<UserCouponsResponse>>
 
     @Operation(summary = "쿠폰 발급 ", description = "사용자에게 쿠폰을 발급 하는 API")
     @PostMapping("/issue")
     fun issueCoupon(
         @RequestBody request: IssueCouponRequest
-    ): ApiResponse<CouponResponse>
+    ): ApiResponse<IssueCouponResponse>
 }

--- a/src/main/kotlin/ecommerce/server/coupon/presentation/dto/CouponResponseDto.kt
+++ b/src/main/kotlin/ecommerce/server/coupon/presentation/dto/CouponResponseDto.kt
@@ -1,10 +1,14 @@
 package ecommerce.server.coupon.presentation.dto
 
+import ecommerce.server.coupon.application.dto.IssueCoupon
+import ecommerce.server.coupon.application.dto.UserCoupons
+import ecommerce.server.coupon.domain.DiscountType
+import ecommerce.server.coupon.domain.model.CouponIssue
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime
 
 @Schema(description = "사용자 쿠폰 응답")
-data class CouponResponse(
+data class UserCouponsResponse(
     @Schema(description = "쿠폰 발급 ID", example = "1")
     val couponIssueId: Long,
 
@@ -15,17 +19,72 @@ data class CouponResponse(
     val couponName: String,
 
     @Schema(description = "할인 타입", example = "FIXED")
-    val discountType: String,
+    val discountType: DiscountType,
 
     @Schema(description = "할인 값", example = "5000")
-    val discountValue: String,
+    val discountValue: Long,
 
     @Schema(description = "발급일", example = "2025-01-01T00:00:00")
     val issuedAt: LocalDateTime,
 
     @Schema(description = "만료일", example = "2025-01-31T23:59:59")
-    val expiryDate: LocalDateTime,
+    val expiryDate: LocalDateTime
+){
+    companion object {
+        fun from(userCoupons: UserCoupons): UserCouponsResponse {
+            return UserCouponsResponse(
+                couponId = userCoupons.couponId,
+                couponIssueId = userCoupons.couponIssueId,
+                couponName = userCoupons.couponName,
+                discountType = userCoupons.discountType,
+                discountValue = userCoupons.discountValue,
+                issuedAt = userCoupons.issuedAt,
+                expiryDate = userCoupons.expiryDate
+            )
+        }
 
-    @Schema(description = "사용일", example = "null", nullable = true)
-    val usedAt: LocalDateTime?
-)
+        fun listFrom(userCoupons: List<UserCoupons>): List<UserCouponsResponse>{
+            return userCoupons.map {issue ->
+                from(issue)
+            }
+        }
+    }
+}
+
+@Schema(description = "쿠폰 발급 응답")
+data class IssueCouponResponse(
+    @Schema(description = "쿠폰 발급 ID", example = "1")
+    val couponIssueId: Long,
+
+    @Schema(description = "쿠폰 ID", example = "1")
+    val couponId: Long,
+
+    @Schema(description = "쿠폰 이름", example = "신규 가입 쿠폰")
+    val couponName: String,
+
+    @Schema(description = "할인 타입", example = "FIXED")
+    val discountType: DiscountType,
+
+    @Schema(description = "할인 값", example = "5000")
+    val discountValue: Long,
+
+    @Schema(description = "발급일", example = "2025-01-01T00:00:00")
+    val issuedAt: LocalDateTime,
+
+    @Schema(description = "만료일", example = "2025-01-31T23:59:59")
+    val expiryDate: LocalDateTime
+){
+    companion object {
+        fun from(issueCoupon: IssueCoupon): IssueCouponResponse{
+            return IssueCouponResponse(
+                couponId = issueCoupon.couponId,
+                couponIssueId = issueCoupon.couponIssueId,
+                couponName = issueCoupon.couponName,
+                discountType = issueCoupon.discountType,
+                discountValue = issueCoupon.discountValue,
+                issuedAt = issueCoupon.issuedAt,
+                expiryDate = issueCoupon.expiryDate
+            )
+        }
+    }
+}

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -16,3 +16,8 @@ VALUES
     (1, 100, NOW(), NOW()),
     (2, 200, NOW(), NOW()),
     (3, 300, NOW(), NOW());
+
+INSERT INTO ecommerce.coupon (name, discount_type, discount_value, total_quantity, issued_quantity, expiry_date, created_at, updated_at)
+VALUES
+    ('testCoupon1', 'FIXED_AMOUNT', 1000, 10, 0, '2100-01-01 00:00:00', NOW(), NOW()),
+    ('testCoupon2', 'PERCENTAGE', 10, 20, 0, '2100-01-01 00:00:00', NOW(), NOW());


### PR DESCRIPTION
## API
- [x] 쿠폰 094a3e4b638747ecca77afa4fd1457adc3553cbf
- 쿠폰 선착순 발급 기능 구현 
- 유효 쿠폰 사용자 조회 기능 추가
- [ ] 주문
- [ ] 결제


## 변경 사항 요약
### 1. `CouponService`
validateCoupon 메소드에서 쿠폰의 발급 가능 여부를 체크하고, 잠금 처리(lock)를 통해 동시성 문제를 방지하도록 구현되었습니다.

### 2. `CouponIssueService`
사용자에 대해 유효한 쿠폰 목록을 조회하는 getValidCouponsByUserId 메소드 추가
쿠폰 발급을 처리하는 issueCoupon 메소드 추가, 사용자의 쿠폰을 생성하고 저장하는 로직 구현

### 3. `CouponFacade`
getUserValidCoupons: 사용자 ID에 따른 유효한 쿠폰 목록을 DTO로 변환하여 제공
issueFirstComeCoupon: 선착순 쿠폰 발급 로직을 캡슐화하여 CouponService와 CouponIssueService를 연계해서 호출

### 4. `CouponController`
GET /api/coupons
POST /api/coupons/issue


